### PR TITLE
[Fix] Change `build:styles` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	"scripts": {
 		"dev": "vite dev",
 		"build": "svelte-kit sync && svelte-package && npm run build:styles",
-		"build:styles": "postcss ./src/**/*.css --base ./src/lib --dir ./package",
+		"build:styles": "postcss ./src/**/*.css --base ./src/lib --dir ./package && cp -r ./src/lib/styles/mixins ./package/styles",
 		"prepublishOnly": "echo 'Did you mean to publish `./package/`, instead of `./`?' && exit 1",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",


### PR DESCRIPTION
Seems like `"build:styles": "postcss ./src/**/*.css --base ./src/lib --dir ./package",` is currently not bundling the `mixins` (dunno why - the file is just empty) and to solve that we must expand the current command to `"build:styles": "postcss ./src/**/*.css --base ./src/lib --dir ./package && cp -r ./src/lib/styles/mixins ./package/styles",`