### PR TITLE
fix(forms): fields outline on focus safari and windows

### DIFF
--- a/src/lib/components/forms/common.ts
+++ b/src/lib/components/forms/common.ts
@@ -3,7 +3,7 @@ import { cva } from 'class-variance-authority';
 export const base = cva(
   `
   appearance-none
-  outline-0
+  outline-none
 
   bg-foreground/2
   border
@@ -15,11 +15,11 @@ export const base = cva(
   focus:border-border-active
   focus:ring-4
   focus:ring-outline
-  focus:outline-0
+  focus:outline-none
   peer-focus:border-border-active
   peer-focus:ring-4
   peer-focus:ring-outline
-  peer-focus:outline-0
+  peer-focus:outline-none
   checked:bg-outline
 
   disabled:opacity-60


### PR DESCRIPTION
## Description
- Inputs blue outline on certain browsers/OS

### Safari
before:
<img width="599" alt="image" src="https://github.com/significa/significa-svelte-ui/assets/98809371/2326043a-4ddc-4af6-a765-f94d61e7271f">
 
after:
<img width="609" alt="image" src="https://github.com/significa/significa-svelte-ui/assets/98809371/db496792-c567-480c-b173-30dedb0dd94f">

Closes SIGN-463
