### PR TITLE
update: remove clsx lib and use cva cx alias

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@typescript-eslint/parser": "^5.57.1",
         "autoprefixer": "^10.4.14",
         "class-variance-authority": "^0.5.1",
-        "clsx": "^1.2.1",
         "eslint": "^8.37.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-storybook": "^0.6.11",
@@ -46,7 +45,6 @@
       "peerDependencies": {
         "autoprefixer": "^10.4.14",
         "class-variance-authority": "^0.5.1",
-        "clsx": "^1.2.1",
         "postcss": "^8.4.21",
         "svelte": "^3.55.1",
         "tailwind-merge": "^1.11.0",
@@ -5906,15 +5904,6 @@
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
       },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -17762,12 +17751,6 @@
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
       }
-    },
-    "clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "dev": true
     },
     "color-convert": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
   "peerDependencies": {
     "autoprefixer": "^10.4.14",
     "class-variance-authority": "^0.5.1",
-    "clsx": "^1.2.1",
     "postcss": "^8.4.21",
     "svelte": "^3.55.1",
     "tailwind-merge": "^1.11.0",
@@ -80,7 +79,6 @@
     "@typescript-eslint/parser": "^5.57.1",
     "autoprefixer": "^10.4.14",
     "class-variance-authority": "^0.5.1",
-    "clsx": "^1.2.1",
     "eslint": "^8.37.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-storybook": "^0.6.11",

--- a/src/lib/components/avatar.svelte
+++ b/src/lib/components/avatar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import clsx from 'clsx';
+  import { cx } from 'class-variance-authority';
 
   let className: undefined | string = undefined;
   export { className as class };
@@ -9,8 +9,8 @@
 </script>
 
 <div
-  class={clsx('bg-foreground/10 bg-cover bg-center bg-no-repeat', size, className)}
-  style={clsx(image ? `background-image: url(${image})` : '', style)}
+  class={cx('bg-foreground/10 bg-cover bg-center bg-no-repeat', size, className)}
+  style={cx(image ? `background-image: url(${image})` : '', style)}
   {...$$restProps}
 />
 

--- a/src/lib/components/button.svelte
+++ b/src/lib/components/button.svelte
@@ -2,8 +2,7 @@
   import Icon from './icon.svelte';
   import type { IconOptions } from './icon.svelte';
   import Spinner from './spinner.svelte';
-  import { cva, type VariantProps } from 'class-variance-authority';
-  import clsx from 'clsx';
+  import { cva, type VariantProps, cx } from 'class-variance-authority';
   import { twMerge } from 'tailwind-merge';
 
   const button = cva(
@@ -104,7 +103,7 @@
 >
   {#if icon}
     <Icon
-      class={clsx(
+      class={cx(
         icon &&
           arrow && [
             'transition-all',
@@ -119,7 +118,7 @@
   {/if}
   {#if $$slots.default}
     <span
-      class={clsx(
+      class={cx(
         icon &&
           arrow && [
             'transition-all',
@@ -137,7 +136,7 @@
   {/if}
   {#if arrow}
     <Icon
-      class={clsx(
+      class={cx(
         icon &&
           arrow && [
             'absolute',
@@ -156,7 +155,7 @@
   {/if}
   {#if loading}
     <div
-      class={clsx(
+      class={cx(
         'btn-spinner',
         'absolute',
         'left-1/2',

--- a/src/lib/components/forms/file-upload.svelte
+++ b/src/lib/components/forms/file-upload.svelte
@@ -10,8 +10,8 @@
 
 <script lang="ts">
   import type { HTMLInputAttributes } from 'svelte/elements';
-  import type { VariantProps } from 'class-variance-authority';
-  import clsx from 'clsx';
+  import { cx, type VariantProps } from 'class-variance-authority';
+
   import { twMerge } from 'tailwind-merge';
   import CircleButton from '../circle-button.svelte';
   import Icon from '../icon.svelte';
@@ -122,7 +122,7 @@
       {...inputProps}
     />
     <div
-      class={clsx(base(), inputStyle({ size }), 'cursor-pointer', files.length && 'rounded-b-none')}
+      class={cx(base(), inputStyle({ size }), 'cursor-pointer', files.length && 'rounded-b-none')}
     >
       <div class="flex items-center gap-2 text-foreground-secondary">
         <Icon icon="attachment" />
@@ -141,7 +141,7 @@
     >
       {#each files as file}
         <div
-          class={clsx(
+          class={cx(
             'group flex items-center justify-between transition-colors hover:bg-foreground/2',
             size === 'sm' ? 'p-2' : 'p-3'
           )}

--- a/src/lib/components/toasts/toaster.svelte
+++ b/src/lib/components/toasts/toaster.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { reducedMotion } from '$lib/stores/reduced-motion';
-  import clsx from 'clsx';
+  import { cx } from 'class-variance-authority';
   import { setContext, type ComponentType, type SvelteComponentTyped } from 'svelte';
   import { flip } from 'svelte/animate';
   import { circOut } from 'svelte/easing';
@@ -23,10 +23,10 @@
   });
 </script>
 
-<div class={clsx('toasts', position, `gap-${gap}`, `inset-${inset}`, className)}>
+<div class={cx('toasts', position, `gap-${gap}`, `inset-${inset}`, className)}>
   {#each $toastStore as { component: toastComponent, ...toast } (toast.id)}
     <div
-      class={clsx('toast', toast.class || wrapper?.class)}
+      class={cx('toast', toast.class || wrapper?.class)}
       use:pausableTimeout={{ ms: toast.timeout, reoccurredAt: toast.reoccurredAt }}
       on:timeout={() => toastStore.clear(toast.id)}
       animate:flip={{ duration: $reducedMotion ? 0 : 800, easing: circOut }}


### PR DESCRIPTION

Class variance authority lib has an alias for [clsx](https://github.com/lukeed/clsx) function.

I think the `clsx` can be removed and use cva `cx` function instead.

CVA docs:
https://cva.style/docs/api-reference

ps: it looks like it works fine, but didn't do much testing, so take this PR with a grain of salt.

Lastly, thanks for open sourcing your website repos 👏
